### PR TITLE
Create Skeleton for Lockdrop Page Component Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .vercel
+.vscode/settings.json

--- a/components/ApolloCardBody.tsx
+++ b/components/ApolloCardBody.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable no-ternary */
+import React, { FC, ReactNode } from "react"
+import { Box, BoxProps } from "@chakra-ui/react"
+
+type Props = {
+  children: ReactNode
+  noPadding?: boolean
+} & BoxProps
+
+const ApolloCardBody: FC<Props> = ({ children, noPadding = false, ...props }) => {
+  const py = !noPadding ? "6" : "0"
+  const px = !noPadding ? "8" : "0"
+
+  return (
+    <Box
+      bg='white.50'
+      py={py}
+      px={px}
+      borderBottomRightRadius='2xl'
+      borderBottomLeftRadius='2xl'
+      position='relative'
+      color='white'
+      {...props}
+    >
+      {children}
+    </Box>
+  )
+}
+
+export default ApolloCardBody

--- a/components/ApolloCardHeader.tsx
+++ b/components/ApolloCardHeader.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable no-ternary */
+import React, { FC, ReactNode } from "react"
+import { Box, BoxProps } from "@chakra-ui/react"
+
+type Props = {
+  children: ReactNode
+  noPadding?: boolean
+} & BoxProps
+
+const ApolloCardHeader: FC<Props> = ({ children, noPadding = false, ...props }) => {
+  const py = !noPadding ? "6" : "0"
+  const px = !noPadding ? "8" : "0"
+
+  return (
+    <Box
+      bg='white.50'
+      py={py}
+      px={px}
+      borderBottomWidth='2px'
+      borderColor='white.100'
+      borderTopRightRadius='2xl'
+      borderTopLeftRadius='2xl'
+      position='relative'
+      color='white'
+      {...props}
+    >
+      {children}
+    </Box>
+  )
+}
+
+export default ApolloCardHeader

--- a/components/LockdropOverview.tsx
+++ b/components/LockdropOverview.tsx
@@ -1,0 +1,25 @@
+import React, { FC, ReactNode } from "react"
+import { Box, Flex, Link, Spacer, VStack } from "@chakra-ui/react"
+import ApolloCardHeader from "./ApolloCardHeader"
+import ApolloCardBody from "./ApolloCardBody"
+import ExternalLinkIcon from "./icons/ExternalLinkIcon"
+
+type Props = {}
+
+const LockdropOverview: FC<Props> = ({}) => {
+  return (
+    <VStack my='0' spacing='0' align='stretch'>
+      <ApolloCardHeader>
+        <Flex direction={"row"}>
+          <h2>xASTRO Lockdrop</h2>
+          <Spacer />
+          <Link>Learn more</Link>
+          <ExternalLinkIcon mt={2} />
+        </Flex>
+      </ApolloCardHeader>
+      <ApolloCardBody>Yo</ApolloCardBody>
+    </VStack>
+  )
+}
+
+export default LockdropOverview

--- a/components/LockdropPageHeader.tsx
+++ b/components/LockdropPageHeader.tsx
@@ -1,0 +1,44 @@
+import React, { FC, ReactNode } from "react"
+import {
+  Box,
+  HStack,
+  Link,
+  Stack,
+  Flex,
+  Spacer,
+  VStack,
+  Icon,
+  FlexProps,
+  Grid,
+} from "@chakra-ui/react"
+import CardHeader from "./CardHeader"
+import Card from "./Card"
+import ApolloCardBody from "./ApolloCardBody"
+import ApolloCardHeader from "./ApolloCardHeader"
+import ExternalLinkIcon from "components/icons/ExternalLinkIcon"
+
+type Props = {}
+
+const LockdropPageHeader: FC<Props> = ({}) => {
+  return (
+    <VStack my='0' spacing='2' align='stretch'>
+      <Grid templateColumns='repeat(3, 1fr)' gap={6}>
+        <Box px='5'>
+          <h2>Stage I</h2>
+          <p>
+            During Stage 1 (Day 1-5) there are no limits on deposits and withdrawals of xASTRO. Once
+            Stage 2 (Day 6) begins yo uwill only be able to withdraw xASTRO.
+          </p>
+        </Box>
+        <Box px='5'>
+          <h2>TIME LEFT IN THIS STAGE</h2>
+        </Box>
+        <Box px='5'>
+          <h2>Timeline</h2>
+        </Box>
+      </Grid>
+    </VStack>
+  )
+}
+
+export default LockdropPageHeader

--- a/components/MyLockdropDeposits.tsx
+++ b/components/MyLockdropDeposits.tsx
@@ -1,0 +1,54 @@
+import React, { FC, ReactNode } from "react"
+import { Box, Flex, Link, Spacer, VStack } from "@chakra-ui/react"
+import ApolloCardHeader from "./ApolloCardHeader"
+import ApolloCardBody from "./ApolloCardBody"
+import ExternalLinkIcon from "./icons/ExternalLinkIcon"
+import MyLockdropDepositsHeader from "./MyLockdropDepositsHeader"
+import MyLockdropDepositsRow from "./MyLockdropDepositsRow"
+
+type Props = {}
+
+const deposits = [
+  {
+    amount: 15000,
+    unlocksOn: "2023-04-06T00:00:00.000Z",
+    rewards: 75000,
+    percentOfRewards: 0.7,
+  },
+  {
+    amount: 5000,
+    unlocksOn: "2022-06-06T00:00:00.000Z",
+    rewards: 55000,
+    percentOfRewards: 0.25,
+  },
+]
+
+const MyLockdropDeposits: FC<Props> = () => {
+  return (
+    <VStack my='0' spacing='0' align='stretch'>
+      <ApolloCardHeader>
+        <Flex direction={"row"}>
+          <h2>My Lockdrop Deposits</h2>
+          <Spacer />
+          <Link>Learn more</Link>
+          <ExternalLinkIcon mt={2} />
+        </Flex>
+      </ApolloCardHeader>
+      <MyLockdropDepositsHeader />
+      {deposits.map((deposit: any, i: number) => {
+        const { amount, unlocksOn, rewards, percentOfRewards } = deposit
+        return (
+          <MyLockdropDepositsRow
+            key={"row-" + i}
+            amount={amount}
+            unlocksOn={unlocksOn}
+            rewards={rewards}
+            percentOfRewards={percentOfRewards}
+          />
+        )
+      })}
+    </VStack>
+  )
+}
+
+export default MyLockdropDeposits

--- a/components/MyLockdropDepositsHeader.tsx
+++ b/components/MyLockdropDepositsHeader.tsx
@@ -1,0 +1,52 @@
+import React, { FC, ReactNode } from "react"
+import { Box, Flex, HStack, Link, Spacer, Stack, VStack } from "@chakra-ui/react"
+import ApolloCardHeader from "./ApolloCardHeader"
+import ApolloCardBody from "./ApolloCardBody"
+import ExternalLinkIcon from "./icons/ExternalLinkIcon"
+
+type Props = {}
+
+const deposits = [
+  {
+    amount: 15000,
+    unlocksOn: "2023-04-06T00:00:00.000Z",
+    rewards: 75000,
+    percentOfRewards: 0.7,
+  },
+  {
+    amount: 5000,
+    unlocksOn: "2022-06-06T00:00:00.000Z",
+    rewards: 55000,
+    percentOfRewards: 0.25,
+  },
+]
+
+const MyLockdropDepositsHeader: FC<Props> = () => {
+  return (
+    <HStack
+      my='0'
+      spacing='0'
+      align='stretch'
+      bg='white.50'
+      px='8'
+      py='4'
+      fontSize='.8rem'
+      borderBottomWidth='2px'
+      borderColor='white.100'
+      position='relative'
+      color='whiteAlpha.500'
+    >
+      <Box>Amount Locked</Box>
+      <Spacer />
+      <Box>Fully Unlocks On</Box>
+      <Spacer />
+      <Box>Est. Lockdrop Rewards</Box>
+      <Spacer />
+      <Box>Est. % of Lockdrop Rewards</Box>
+      <Spacer />
+      <Box>Actions</Box>
+    </HStack>
+  )
+}
+
+export default MyLockdropDepositsHeader

--- a/components/MyLockdropDepositsRow.tsx
+++ b/components/MyLockdropDepositsRow.tsx
@@ -1,0 +1,52 @@
+import React, { FC, ReactNode } from "react"
+import { Box, Button, Flex, HStack, Link, Spacer, Stack, VStack } from "@chakra-ui/react"
+import ApolloCardHeader from "./ApolloCardHeader"
+import ApolloCardBody from "./ApolloCardBody"
+import ExternalLinkIcon from "./icons/ExternalLinkIcon"
+
+type Props = {
+  amount: any
+  unlocksOn: string
+  rewards: number
+  percentOfRewards: number
+}
+
+const MyLockdropDepositsRow: FC<Props> = ({
+  amount,
+  unlocksOn,
+  rewards,
+  percentOfRewards,
+}: Props) => {
+  return (
+    <HStack
+      my='0'
+      spacing='0'
+      align='stretch'
+      px='8'
+      py='4'
+      background={"whiteAlpha.50"}
+      borderBottomWidth='2px'
+      borderColor='white.100'
+      position='relative'
+      color='whiteAlpha.500'
+      _last={{
+        borderBottomWidth: "0",
+        borderBottomRadius: 10,
+      }}
+    >
+      <Box>{amount}</Box>
+      <Spacer />
+      <Box>{new Date().toLocaleDateString()}</Box>
+      <Spacer />
+      <Box>{rewards}</Box>
+      <Spacer />
+      <Box>{percentOfRewards}</Box>
+      <Spacer />
+      <Box>
+        <Button>Withdraw</Button>
+      </Box>
+    </HStack>
+  )
+}
+
+export default MyLockdropDepositsRow

--- a/components/MyxAstroTable.tsx
+++ b/components/MyxAstroTable.tsx
@@ -1,0 +1,39 @@
+import React, { FC, ReactNode } from "react"
+import { Box, Flex, Link, Spacer, VStack } from "@chakra-ui/react"
+import ApolloCardHeader from "./ApolloCardHeader"
+import MyLockdropDepositsHeader from "./MyLockdropDepositsHeader"
+import MyxAstroTableRow from "./MyxAstroTableRow"
+import ExternalLinkIcon from "./icons/ExternalLinkIcon"
+import MyxAstroTableHeader from "./MyxAstroTableHeader"
+
+type Props = {}
+
+const assets = [
+  {
+    name: "xASTRO",
+    amount: 20000,
+    inWallet: 2500,
+  },
+]
+
+const MyxAstroTable: FC<Props> = ({}) => {
+  return (
+    <VStack my='0' spacing='0' align='stretch'>
+      <ApolloCardHeader>
+        <Flex direction={"row"}>
+          <h2>My Lockdrop Deposits</h2>
+          <Spacer />
+          <Link>Learn more</Link>
+          <ExternalLinkIcon mt={2} />
+        </Flex>
+      </ApolloCardHeader>
+      <MyxAstroTableHeader />
+      {assets.map((assetRecord: any, i: number) => {
+        const { name, amount, inWallet } = assetRecord
+        return <MyxAstroTableRow key={"row-" + i} name={name} amount={amount} inWallet={inWallet} />
+      })}
+    </VStack>
+  )
+}
+
+export default MyxAstroTable

--- a/components/MyxAstroTableHeader.tsx
+++ b/components/MyxAstroTableHeader.tsx
@@ -1,0 +1,35 @@
+import React, { FC, ReactNode } from "react"
+import { Box, Flex, HStack, Link, Spacer, Stack, VStack } from "@chakra-ui/react"
+import ApolloCardHeader from "./ApolloCardHeader"
+import ApolloCardBody from "./ApolloCardBody"
+import ExternalLinkIcon from "./icons/ExternalLinkIcon"
+
+type Props = {}
+
+const MyxAstroTableHeader: FC<Props> = () => {
+  return (
+    <HStack
+      my='0'
+      spacing='0'
+      align='stretch'
+      bg='white.50'
+      px='8'
+      py='4'
+      fontSize='.8rem'
+      borderBottomWidth='2px'
+      borderColor='white.100'
+      position='relative'
+      color='whiteAlpha.500'
+    >
+      <Box>Asset</Box>
+      <Spacer />
+      <Box>In Lockdrop</Box>
+      <Spacer />
+      <Box>In Wallet</Box>
+      <Spacer />
+      <Box>Actions</Box>
+    </HStack>
+  )
+}
+
+export default MyxAstroTableHeader

--- a/components/MyxAstroTableRow.tsx
+++ b/components/MyxAstroTableRow.tsx
@@ -1,0 +1,44 @@
+import React, { FC, ReactNode } from "react"
+import { Box, Button, Flex, HStack, Link, Spacer, Stack, VStack } from "@chakra-ui/react"
+import ApolloCardHeader from "./ApolloCardHeader"
+import ApolloCardBody from "./ApolloCardBody"
+import ExternalLinkIcon from "./icons/ExternalLinkIcon"
+
+type Props = {
+  name: any
+  amount: string
+  inWallet: number
+}
+
+const MyxAstroTableRow: FC<Props> = ({ name, amount, inWallet }: Props) => {
+  return (
+    <HStack
+      my='0'
+      spacing='0'
+      align='stretch'
+      px='8'
+      py='4'
+      background={"whiteAlpha.50"}
+      borderBottomWidth='2px'
+      borderColor='white.100'
+      position='relative'
+      color='whiteAlpha.500'
+      _last={{
+        borderBottomWidth: "0",
+        borderBottomRadius: 10,
+      }}
+    >
+      <Box>{name}</Box>
+      <Spacer />
+      <Box>{amount}</Box>
+      <Spacer />
+      <Box>{inWallet}</Box>
+      <Spacer />
+      <Box>
+        <Button>Lock xASTRO</Button>
+      </Box>
+    </HStack>
+  )
+}
+
+export default MyxAstroTableRow

--- a/components/Table.tsx
+++ b/components/Table.tsx
@@ -1,12 +1,12 @@
-import React, { FC, ReactNode } from "react";
-import { Box } from "@chakra-ui/react";
+import React, { FC, ReactNode } from "react"
+import { Box } from "@chakra-ui/react"
 
 type Props = {
-  children: ReactNode;
-};
+  children: ReactNode
+}
 
 const Table: FC<Props> = ({ children }) => {
-  return <Box color="white">{children}</Box>;
-};
+  return <Box color='white'>{children}</Box>
+}
 
-export default Table;
+export default Table

--- a/components/pages/Phase2.tsx
+++ b/components/pages/Phase2.tsx
@@ -1,22 +1,28 @@
-import React from "react";
-import { VStack } from "@chakra-ui/react";
-import dayjs from "dayjs";
+import React from "react"
+import { VStack } from "@chakra-ui/react"
+import dayjs from "dayjs"
 
-import { useAstroApp } from "modules/common";
+import { useAstroApp } from "modules/common"
 
-import LaunchTimeline from "components/LaunchTimeline";
-import Phase2Bootstrap from "components/Phase2Bootstrap";
-import AddLiquidity from "components/AddLiquidity";
-import AstroAirdrop from "components/AstroAirdrop";
+import LaunchTimeline from "components/LaunchTimeline"
+import Phase2Bootstrap from "components/Phase2Bootstrap"
+import AddLiquidity from "components/AddLiquidity"
+import AstroAirdrop from "components/AstroAirdrop"
+import Table from "components/Table"
+import Card from "components/Card"
+import LockdropPageHeader from "components/LockdropPageHeader"
+import LockdropOverview from "components/LockdropOverview"
+import MyxAstroTable from "components/MyxAstroTable"
+import MyLockdropDeposits from "components/MyLockdropDeposits"
 
 const Phase2 = () => {
-  const { phase2EndDate } = useAstroApp();
-  const phase2EndTimestamp = phase2EndDate?.unix();
-  const timestamp = dayjs().unix();
-  const currentPhase = phase2EndTimestamp < timestamp ? 3 : 2;
+  const { phase2EndDate } = useAstroApp()
+  const phase2EndTimestamp = phase2EndDate?.unix()
+  const timestamp = dayjs().unix()
+  const currentPhase = phase2EndTimestamp < timestamp ? 3 : 2
 
   return (
-    <VStack my="12" spacing="16" align="stretch">
+    <VStack my='12' spacing='16' align='stretch'>
       {/* <Notification variant="info">
         Thank you for participating in phase 1, 3,000 ASTRO were added to your
         ASTRO Balance. <Link>Learn More</Link>
@@ -29,12 +35,17 @@ const Phase2 = () => {
         Thank you for participating in phase 1, 3,000 ASTRO were added to your
         ASTRO Balance. <Link>Learn More</Link>
       </Notification> */}
-      <LaunchTimeline phase={currentPhase} />
+      {/* <LaunchTimeline phase={currentPhase} />
       <Phase2Bootstrap />
       <AddLiquidity />
-      <AstroAirdrop />
-    </VStack>
-  );
-};
+      <AstroAirdrop /> */}
 
-export default Phase2;
+      <LockdropPageHeader />
+      <LockdropOverview />
+      <MyxAstroTable />
+      <MyLockdropDeposits />
+    </VStack>
+  )
+}
+
+export default Phase2


### PR DESCRIPTION
feat: create page layout components for the lockdrop page with dummy data. 

This in a work in progress.

![image](https://user-images.githubusercontent.com/3955528/165444154-e2854c48-5f7e-4333-ac7d-fe1c1021b266.png)
